### PR TITLE
44503 - removed GetById document repository method, to cater for partitioned collections

### DIFF
--- a/src/Api/Dfe.Rscd.Api/Dfe.Rscd.Api.Infrastructure/CosmosDb/Repositories/CosmosDocumentRepository.cs
+++ b/src/Api/Dfe.Rscd.Api/Dfe.Rscd.Api.Infrastructure/CosmosDb/Repositories/CosmosDocumentRepository.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Net;
 using Dfe.Rscd.Api.Infrastructure.CosmosDb.Config;
 using Microsoft.Azure.Cosmos;
 
@@ -12,16 +11,6 @@ namespace Dfe.Rscd.Api.Infrastructure.CosmosDb.Repositories
         public CosmosDocumentRepository(CosmosDbOptions options)
         {
             _cosmosDb = new CosmosClient(options.Account, options.Key).GetDatabase(options.Database);
-        }
-
-        public T GetById<T>(string collection, string id)
-        {
-            var container = _cosmosDb.GetContainer(collection);
-            var result = container.ReadItemAsync<T>(id, PartitionKey.None).Result;
-            if (result.StatusCode == HttpStatusCode.OK) 
-                return result.Resource;
-
-            return default(T);
         }
 
         public IQueryable<T> Get<T>(string collection)

--- a/src/Api/Dfe.Rscd.Api/Dfe.Rscd.Api.Infrastructure/CosmosDb/Repositories/IDocumentRepository.cs
+++ b/src/Api/Dfe.Rscd.Api/Dfe.Rscd.Api.Infrastructure/CosmosDb/Repositories/IDocumentRepository.cs
@@ -5,7 +5,5 @@ namespace Dfe.Rscd.Api.Infrastructure.CosmosDb.Repositories
     public interface IDocumentRepository
     {
         IQueryable<T> Get<T>(string collection);
-
-        T GetById<T>(string collection, string id);
     }
 }

--- a/src/Api/Dfe.Rscd.Api/Dfe.Rscd.Api.Services/Pupil/PupilService.cs
+++ b/src/Api/Dfe.Rscd.Api/Dfe.Rscd.Api.Services/Pupil/PupilService.cs
@@ -28,8 +28,17 @@ namespace Dfe.Rscd.Api.Services
 
         public Pupil GetById(CheckingWindow checkingWindow, string id)
         {
-            var pupilDTO = _documentRepository.GetById<PupilDTO>(GetCollection(checkingWindow), id);
-            return GetPupil(checkingWindow, pupilDTO, _allocationYear);
+            var pupilDtos = _documentRepository
+                .Get<PupilDTO>(GetCollection(checkingWindow))
+                .Where(x => x.id == id)
+                .ToList();
+
+            if (pupilDtos.Any())
+            {
+                return GetPupil(checkingWindow, pupilDtos.First(), _allocationYear);
+            }
+
+            return null;
         }
 
         public List<PupilRecord> QueryPupils(CheckingWindow checkingWindow, PupilsSearchRequest query)
@@ -68,7 +77,7 @@ namespace Dfe.Rscd.Api.Services
             return $"{checkingWindow.ToString().ToLower()}_pupils_{_allocationYear}";
         }
 
-        public Pupil GetPupil(CheckingWindow checkingWindow, PupilDTO pupil, string allocationYear)
+        private Pupil GetPupil(CheckingWindow checkingWindow, PupilDTO pupil, string allocationYear)
         {
             var sen = _dataService.GetSENStatus().SingleOrDefault(x=>x.Code == pupil.SENStatusCode);
             var pincl = _dataService.GetPINCLs().SingleOrDefault(x => x.Code == pupil.P_INCL);

--- a/src/Api/Dfe.Rscd.Api/Dfe.Rscd.Api.UnitTests/EstablishmentServiceTests.cs
+++ b/src/Api/Dfe.Rscd.Api/Dfe.Rscd.Api.UnitTests/EstablishmentServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Dfe.Rscd.Api.Domain.Entities;
 using Dfe.Rscd.Api.Infrastructure.CosmosDb.Config;
 using Dfe.Rscd.Api.Infrastructure.CosmosDb.DTOs;
@@ -18,19 +19,14 @@ namespace Dfe.Rscd.Api.UnitTests
         
         private void Given()
         {
-            _testEstab = Builder.GetEstablishment("200000");
+            _testUrn = "200000";
+            _testEstab = Builder.GetEstablishment(_testUrn);
 
             _repository = new Mock<IDocumentRepository>();
-            _ks4JuneEstablishments = "ks4june_establishments_2021";
-
-            _repository.Setup(x =>
-                    x.GetById<EstablishmentDTO>(_ks4JuneEstablishments,
-                        It.IsAny<string>()))
-                .Returns(_testEstab);
 
             _repository.Setup(x =>
                     x.Get<EstablishmentDTO>(_ks4JuneEstablishments))
-                .Returns(Builder.GetEstablisments().AsQueryable());
+                .Returns(new List<EstablishmentDTO> { _testEstab }.AsQueryable());
 
             _configuration = new Mock<IAllocationYearConfig>();
             _configuration.Setup(x => x.Value).Returns("2021");
@@ -39,16 +35,17 @@ namespace Dfe.Rscd.Api.UnitTests
         private Mock<IDocumentRepository> _repository;
         private Mock<IAllocationYearConfig> _configuration;
         private EstablishmentDTO _testEstab;
-        private string _ks4JuneEstablishments;
+        private const string _ks4JuneEstablishments = "ks4june_establishments_2021";
+        private string _testUrn;
 
         [Fact]
         public void WhenGetEstablishmentByURNIsCalledEstablishmentDTOMapsRootFieldsToEntityObject()
         {
             var establishmentService = new EstablishmentService(_repository.Object, _configuration.Object);
 
-            var result = establishmentService.GetByURN(CheckingWindow.KS4June, new URN("200000"));
+            var result = establishmentService.GetByURN(CheckingWindow.KS4June, new URN(_testUrn));
 
-            _repository.Verify(x => x.GetById<EstablishmentDTO>(_ks4JuneEstablishments, "200000"), Times.Once);
+            _repository.Verify(x => x.Get<EstablishmentDTO>(_ks4JuneEstablishments), Times.Once);
 
             Assert.NotNull(result);
             Assert.True(result.DfesNumber.ToString() == _testEstab.DFESNumber);
@@ -58,7 +55,7 @@ namespace Dfe.Rscd.Api.UnitTests
             Assert.True(result.LowestAge == _testEstab.LowestAge);
             Assert.True(result.HighestAge == _testEstab.HighestAge);
             Assert.True(result.HeadTeacher == _testEstab.HeadTitleCode+ " " +_testEstab.HeadFirstName + " " +_testEstab.HeadLastName);
-            Assert.True(result.Urn.Value == "200000");
+            Assert.True(result.Urn.Value == _testUrn);
         }
 
         [Fact]
@@ -66,15 +63,15 @@ namespace Dfe.Rscd.Api.UnitTests
         {
             var establishmentService = new EstablishmentService(_repository.Object, _configuration.Object);
 
-            var result = establishmentService.GetByDFESNumber(CheckingWindow.KS4June, "99100000");
+            var result = establishmentService.GetByDFESNumber(CheckingWindow.KS4June, $"99{_testUrn}");
 
             _repository.Verify(x => x.Get<EstablishmentDTO>(_ks4JuneEstablishments), Times.Once);
 
             Assert.NotNull(result);
-            Assert.True(result.DfesNumber == 99100000);
+            Assert.True(result.DfesNumber == int.Parse($"99{_testUrn}"));
             Assert.True(result.SchoolName == _testEstab.SchoolName);
             Assert.True(result.SchoolType == _testEstab.SchoolType);
-            Assert.True(result.Urn.Value == "100000");
+            Assert.True(result.Urn.Value == _testUrn);
         }
 
         [Fact]
@@ -82,9 +79,9 @@ namespace Dfe.Rscd.Api.UnitTests
         {
             var establishmentService = new EstablishmentService(_repository.Object, _configuration.Object);
 
-            var result = establishmentService.GetByURN(CheckingWindow.KS4June, new URN("200000"));
+            var result = establishmentService.GetByURN(CheckingWindow.KS4June, new URN(_testUrn));
 
-            _repository.Verify(x => x.GetById<EstablishmentDTO>(_ks4JuneEstablishments, "200000"), Times.Once);
+            _repository.Verify(x => x.Get<EstablishmentDTO>(_ks4JuneEstablishments), Times.Once);
 
             Assert.NotNull(result);
             Assert.NotNull(result.PerformanceMeasures);

--- a/src/Api/Dfe.Rscd.Api/Dfe.Rscd.Api.UnitTests/PupilServicesTests.cs
+++ b/src/Api/Dfe.Rscd.Api/Dfe.Rscd.Api.UnitTests/PupilServicesTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Dfe.Rscd.Api.Domain.Entities;
 using Dfe.Rscd.Api.Infrastructure.CosmosDb.Config;
 using Dfe.Rscd.Api.Infrastructure.CosmosDb.DTOs;
@@ -30,15 +31,6 @@ namespace Dfe.Rscd.Api.UnitTests
             _ks4JuneEstablishments = "ks4june_establishments_2021";
 
             _repository.Setup(x =>
-                    x.GetById<PupilDTO>(_ks4JunePupils,
-                        It.IsAny<string>()))
-                .Returns(_testPupil);
-
-            _repository.Setup(x =>
-                    x.Get<PupilDTO>(_ks4JunePupils))
-                .Returns(Builder.GetPupils().AsQueryable());
-
-            _repository.Setup(x =>
                     x.Get<EstablishmentDTO>(_ks4JuneEstablishments))
                 .Returns(Builder.GetEstablishment(123232).AsQueryable());
 
@@ -65,6 +57,20 @@ namespace Dfe.Rscd.Api.UnitTests
                 new EstablishmentService(_repository.Object, _configuration.Object), _configuration.Object);
         }
 
+        private void GivenRepoReturnsSingleTestPupil()
+        {
+            _repository.Setup(x =>
+                    x.Get<PupilDTO>(_ks4JunePupils))
+                .Returns(new List<PupilDTO> { _testPupil }.AsQueryable());
+        }
+
+        private void GivenRepoReturnsMultipleTestPupils()
+        {
+            _repository.Setup(x =>
+                    x.Get<PupilDTO>(_ks4JunePupils))
+                .Returns(Builder.GetPupils().AsQueryable());
+        }
+
         private Mock<IDocumentRepository> _repository;
         private Mock<IAllocationYearConfig> _configuration;
         private Mock<IDataRepository> _dataRepository;
@@ -78,9 +84,11 @@ namespace Dfe.Rscd.Api.UnitTests
         [Fact]
         public void WhenGetPupilByIdIsCalledPupilMapsRootFieldsToEntityObject()
         {
+            GivenRepoReturnsSingleTestPupil();
+
             var result = _pupilService.GetById(CheckingWindow.KS4June, "100");
 
-            _repository.Verify(x => x.GetById<PupilDTO>(_ks4JunePupils, "100"), Times.Once);
+            _repository.Verify(x => x.Get<PupilDTO>(_ks4JunePupils), Times.Once);
 
             Assert.NotNull(result);
             Assert.True(result.Id == _testPupil.id);
@@ -109,6 +117,8 @@ namespace Dfe.Rscd.Api.UnitTests
         [Fact]
         public void WhenSearchPupilByIdShouldReturnFoundPupil1000ByUPN()
         {
+            GivenRepoReturnsMultipleTestPupils();
+
             var result = _pupilService.QueryPupils(CheckingWindow.KS4June, new PupilsSearchRequest {ID = "11"});
 
             _repository.Verify(x => x.Get<PupilDTO>(_ks4JunePupils), Times.Once);
@@ -121,6 +131,8 @@ namespace Dfe.Rscd.Api.UnitTests
         [Fact]
         public void WhenSearchPupilByIdShouldReturnFoundPupil1000ByULN()
         {
+            GivenRepoReturnsMultipleTestPupils();
+
             var result = _pupilService.QueryPupils(CheckingWindow.KS4June, new PupilsSearchRequest {ID = "101"});
 
             _repository.Verify(x => x.Get<PupilDTO>(_ks4JunePupils), Times.Once);
@@ -133,6 +145,8 @@ namespace Dfe.Rscd.Api.UnitTests
         [Fact]
         public void WhenSearchPupilByIdShouldReturnFoundPupil2000ByUPN()
         {
+            GivenRepoReturnsMultipleTestPupils();
+
             var result = _pupilService.QueryPupils(CheckingWindow.KS4June, new PupilsSearchRequest {ID = "22"});
 
             _repository.Verify(x => x.Get<PupilDTO>(_ks4JunePupils), Times.Once);
@@ -145,6 +159,8 @@ namespace Dfe.Rscd.Api.UnitTests
         [Fact]
         public void WhenSearchPupilByIdShouldReturnFoundPupil2000ByULN()
         {
+            GivenRepoReturnsMultipleTestPupils();
+
             var result = _pupilService.QueryPupils(CheckingWindow.KS4June, new PupilsSearchRequest {ID = "202"});
 
             _repository.Verify(x => x.Get<PupilDTO>(_ks4JunePupils), Times.Once);
@@ -156,6 +172,8 @@ namespace Dfe.Rscd.Api.UnitTests
         [Fact]
         public void WhenSearchPupilByNameShouldReturnMatchedPupils()
         {
+            GivenRepoReturnsMultipleTestPupils();
+
             var result = _pupilService.QueryPupils(CheckingWindow.KS4June, new PupilsSearchRequest {Name = "Mar"});
 
             _repository.Verify(x => x.Get<PupilDTO>(_ks4JunePupils), Times.Once);
@@ -169,9 +187,11 @@ namespace Dfe.Rscd.Api.UnitTests
         [Fact]
         public void WhenGetPupilByIdIsCalledPupilMapsAllocationYearsToEntityObject()
         {
+            GivenRepoReturnsSingleTestPupil();
+
             var result = _pupilService.GetById(CheckingWindow.KS4June, "100");
 
-            _repository.Verify(x => x.GetById<PupilDTO>(_ks4JunePupils, "100"), Times.Once);
+            _repository.Verify(x => x.Get<PupilDTO>(_ks4JunePupils), Times.Once);
 
             Assert.NotNull(result);
             Assert.True(result.Allocations.Count == 3);
@@ -186,9 +206,11 @@ namespace Dfe.Rscd.Api.UnitTests
         [Fact]
         public void WhenGetPupilByIdIsCalledPupilMapsPerformanceToEntityObject()
         {
+            GivenRepoReturnsSingleTestPupil();
+
             var result = _pupilService.GetById(CheckingWindow.KS4June, "100");
 
-            _repository.Verify(x => x.GetById<PupilDTO>(_ks4JunePupils, "100"), Times.Once);
+            _repository.Verify(x => x.Get<PupilDTO>(_ks4JunePupils), Times.Once);
 
             Assert.NotNull(result);
             Assert.True(result.Results.Count == 1);


### PR DESCRIPTION
Otherwise would of required more significant code changes to pass through partition key value whenever GetById() was going to called.